### PR TITLE
Bugifxes and TradeAction addition

### DIFF
--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -114,8 +114,8 @@ namespace Eco.Mods.Companies
                     CompanyManager.Obj.InterceptReputationTransfer(reputationTransferAction, ref result);
                     break;
                 case TradeAction tradeAction:
-					CompanyManager.Obj.InterceptTradeAction(tradeAction, ref result);
-					break;
+                    CompanyManager.Obj.InterceptTradeAction(tradeAction, ref result);
+                    break;
             }
             return result;
         }

--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -112,15 +112,10 @@ namespace Eco.Mods.Companies
                     break;
                 case ReputationTransfer reputationTransferAction: // intercepts new reputation actions
                     CompanyManager.Obj.InterceptReputationTransfer(reputationTransferAction, ref result);
-                    if (result.Success) // update both sides if we had success
-                    {
-                        Task.Delay(CompaniesPlugin.TaskDelay).ContinueWith(t =>
-                        {
-                            Company.GetEmployer(reputationTransferAction.ReputationSender)?.UpdateLegalPersonReputation();
-                            Company.GetEmployer(reputationTransferAction.ReputationReceiver)?.UpdateLegalPersonReputation();
-                        });
-                    }
                     break;
+                case TradeAction tradeAction:
+					CompanyManager.Obj.InterceptTradeAction(tradeAction, ref result);
+					break;
             }
             return result;
         }

--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -168,14 +168,23 @@ namespace Eco.Mods.Companies
             GameData.Obj.VoidStorageManager.VoidStorages.Callbacks.OnAdd.Add(OnVoidStorageAdded);
             PropertyManager.DeedDestroyedEvent.Add(OnDeedDestroyed);
             PropertyManager.DeedOwnerChangedEvent.Add(OnDeedOwnerChanged);
-        }
+			UserManager.OnUserLoggedOut.Add(OnUserLoggedOut);
+		}
 
         internal static void OnPostInitialize()
         {
             Registrars.Get<Company>().ForEach(company => company.OnPostInitialized());
-        }
 
-        private void OnBankAccountPermissionsChanged(BankAccount bankAccount)
+		}
+
+        private static void OnUserLoggedOut(User user)
+        {
+            var userEmployer = Company.GetEmployer(user);
+            userEmployer?.UpdateOnlineState();
+
+		}
+
+		private void OnBankAccountPermissionsChanged(BankAccount bankAccount)
         {
             if (ignoreBankAccountPermissionsChanged) { return; }
             if (bankAccount == null || bankAccount.DualPermissions == null) { return; }

--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -168,23 +168,23 @@ namespace Eco.Mods.Companies
             GameData.Obj.VoidStorageManager.VoidStorages.Callbacks.OnAdd.Add(OnVoidStorageAdded);
             PropertyManager.DeedDestroyedEvent.Add(OnDeedDestroyed);
             PropertyManager.DeedOwnerChangedEvent.Add(OnDeedOwnerChanged);
-			UserManager.OnUserLoggedOut.Add(OnUserLoggedOut);
-		}
+            UserManager.OnUserLoggedOut.Add(OnUserLoggedOut);
+        }
 
         internal static void OnPostInitialize()
         {
             Registrars.Get<Company>().ForEach(company => company.OnPostInitialized());
 
-		}
+        }
 
         private static void OnUserLoggedOut(User user)
         {
             var userEmployer = Company.GetEmployer(user);
             userEmployer?.UpdateOnlineState();
 
-		}
+        }
 
-		private void OnBankAccountPermissionsChanged(BankAccount bankAccount)
+        private void OnBankAccountPermissionsChanged(BankAccount bankAccount)
         {
             if (ignoreBankAccountPermissionsChanged) { return; }
             if (bankAccount == null || bankAccount.DualPermissions == null) { return; }

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -839,7 +839,7 @@ namespace Eco.Mods.Companies
 
                 if (currentReputation != LegalPerson.Reputation)
                 {
-                    SendCompanyMessage(Localizer.Do($"{this.UILink()} reputation changed: {TextLoc.StyledNum(currentReputation)} to {TextLoc.StyledNum(LegalPerson.Reputation)} - see {LegalPerson.UILink()} for details..."), NotificationCategory.Reputation, NotificationStyle.InfoBox);
+                    SendCompanyMessage(Localizer.Do($"Reputation for {this.UILink()} changed to {TextLoc.StyledNum(LegalPerson.Reputation)}."), NotificationCategory.Reputation, NotificationStyle.InfoBox);
                 }
             });
         }

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -35,8 +35,8 @@ namespace Eco.Mods.Companies
     using Gameplay.UI;
     using Gameplay.Systems;
 
-	using Simulation.Time;
-	using Shared.Serialization;
+    using Simulation.Time;
+    using Shared.Serialization;
     using Shared.Localization;
     using Shared.Services;
     using Shared.Items;
@@ -729,14 +729,14 @@ namespace Eco.Mods.Companies
         public void UpdateOnlineState()
         {
             if(AllEmployees.Where(x => x.IsOnline).Count() == 0) // set the last online time for legel person to now if all employees logged out
-			{
+            {
                 LegalPerson.GetType().GetProperty("LogoutTime").SetValue(LegalPerson, WorldTime.Seconds, null);
                 LegalPerson.MarkDirty();
             }
         }
 
 
-		public void OnReceiveMoney(MoneyGameAction moneyGameAction)
+        public void OnReceiveMoney(MoneyGameAction moneyGameAction)
         {
             if (inReceiveMoney) { return; }
             inReceiveMoney = true;

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -726,10 +726,13 @@ namespace Eco.Mods.Companies
 
         #endregion
 
-        public void UpdateOnlineState() // set the last online time for out legel person to now if any employee logged in or logout.
-		{
-			LegalPerson.GetType().GetProperty("LogoutTime").SetValue(LegalPerson, WorldTime.Seconds, null);
-			LegalPerson.MarkDirty();
+        public void UpdateOnlineState()
+        {
+            if(AllEmployees.Where(x => x.IsOnline).Count() == 0) // set the last online time for legel person to now if all employees logged out
+			{
+                LegalPerson.GetType().GetProperty("LogoutTime").SetValue(LegalPerson, WorldTime.Seconds, null);
+                LegalPerson.MarkDirty();
+            }
         }
 
 

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -34,8 +34,9 @@ namespace Eco.Mods.Companies
     using Gameplay.Objects;
     using Gameplay.UI;
     using Gameplay.Systems;
-    
-    using Shared.Serialization;
+
+	using Simulation.Time;
+	using Shared.Serialization;
     using Shared.Localization;
     using Shared.Services;
     using Shared.Items;
@@ -725,7 +726,14 @@ namespace Eco.Mods.Companies
 
         #endregion
 
-        public void OnReceiveMoney(MoneyGameAction moneyGameAction)
+        public void UpdateOnlineState() // set the last online time for out legel person to now if any employee logged in or logout.
+		{
+			LegalPerson.GetType().GetProperty("LogoutTime").SetValue(LegalPerson, WorldTime.Seconds, null);
+			LegalPerson.MarkDirty();
+        }
+
+
+		public void OnReceiveMoney(MoneyGameAction moneyGameAction)
         {
             if (inReceiveMoney) { return; }
             inReceiveMoney = true;

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -805,8 +805,8 @@ namespace Eco.Mods.Companies
             // at this point we have to wait a bit to let the reputationmanager recache...
             Task.Delay(CompaniesPlugin.TaskDelay).ContinueWith(t =>
             {
-                var   currentReputation       = LegalPerson.Reputation;
-                float reputationCountPostive  =  0;
+                var currentReputation = LegalPerson.Reputation;
+                float reputationCountPostive  = 0;
                 float reputationCountNegative = 0;
 
                 foreach (var user in AllEmployees)
@@ -843,6 +843,7 @@ namespace Eco.Mods.Companies
                 }
             });
         }
+
         public void UpdateCitizenships()
         {
             if (!CompaniesPlugin.Obj.Config.PropertyLimitsEnabled) { return; }

--- a/EcoCompaniesMod/CompanyManager.cs
+++ b/EcoCompaniesMod/CompanyManager.cs
@@ -258,7 +258,11 @@ namespace Eco.Mods.Companies
             if(targetCompany != null)
             {
                 var boughtOrSold = tradeActionData.BoughtOrSold == BoughtOrSold.Selling ? "sold" : "bought";
-                targetCompany.SendCompanyMessage(Localizer.Do($"{targetCompany.UILinkNullSafe()}: {tradeActionData.Citizen.UILinkNullSafe()} {boughtOrSold} {tradeActionData.NumberOfItems} {tradeActionData.ItemUsed.UILinkNullSafe()} at {tradeActionData.WorldObject.UILinkNullSafe()}"), NotificationCategory.YourTrades);
+
+                lawPostResult.AddPostEffect(() =>
+                {
+                    targetCompany.SendCompanyMessage(Localizer.Do($"{targetCompany.UILinkNullSafe()}: {tradeActionData.Citizen.UILinkNullSafe()} {boughtOrSold} {tradeActionData.NumberOfItems} {tradeActionData.ItemUsed.UILinkNullSafe()} at {tradeActionData.WorldObject.UILinkNullSafe()}"), NotificationCategory.YourTrades);
+                });
             }
         }
 
@@ -353,7 +357,7 @@ namespace Eco.Mods.Companies
             {
                 Task.Delay(CompaniesPlugin.TaskDelay).ContinueWith(t =>
                 {
-                    if(senderCompany != receiverEmployeer)
+                    if(reputationTransferData.TargetType == ReputationTargetType.ReputationGivenToUser) // update only needed if users involved on sender side as we get speaking well bonus (maybe)
                     {
                         senderCompany?.UpdateLegalPersonReputation();
                     }


### PR DESCRIPTION
- Broadcasting of buys and sells to the company stores
- Fixed a bug which prevented company deeds to be rated
- Added checks for "deed" and "user" reputation which is new in V11 and needs a bit of handling as employees could not rate town deeds if any other employee is the mayor (and owner of the deed by that) and reputation is intercepted through modsettings.
- Moved the reputation calculation in the interception to check if we need an update (also because of deed reputation)
- Update Legal Person logout time to reflect employees times

- Don't deny company reputation for non player targets (pictures and culture with plaques - needs some more tuning)
- Don't try to intercept non claimstakes in TakeClaim()
